### PR TITLE
Memory Store option

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "karma-phantomjs-launcher": "~1.0.0",
     "load-grunt-tasks": "~3.4.0",
     "phantomjs-prebuilt": "^2.1.4",
-    "time-grunt": "~1.3.0"
+    "time-grunt": "~1.3.0",
+    "bower": "^1.8.4"
   }
 }


### PR DESCRIPTION
Either call `setStorageType()` or use the `defaultToMemory` setting to choose memory store over cookie store when localStorage is unavailable.